### PR TITLE
튜터 님 피드백 반영

### DIFF
--- a/app/src/main/java/com/nbc/two_of_us/data/ContactDatasource.kt
+++ b/app/src/main/java/com/nbc/two_of_us/data/ContactDatasource.kt
@@ -9,6 +9,7 @@ import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class ContactDatasource(context: Context) {
 
@@ -23,16 +24,9 @@ class ContactDatasource(context: Context) {
 
     private val resolver = context.contentResolver
 
-    /**
-     * 수정 중 ~~~
-     * */
-    fun addContact(contactInfo: ContactInfo) {
-        contactInfoList.add(contactInfo)
-    }
-
     fun getAllContacts(callback: (List<ContactInfo>) -> Unit) {
 
-        CoroutineScope(Dispatchers.Main).launch {
+        CoroutineScope(Dispatchers.IO).launch {
             val phoneCursor = resolver.query(
                 Phone.CONTENT_URI,
                 phoneProjection,
@@ -96,7 +90,7 @@ class ContactDatasource(context: Context) {
                                 val nIdIndex = noteCursorNonNull.getColumnIndex(noteProjection[0])
                                 val nNoteIndex = noteCursorNonNull.getColumnIndex(noteProjection[1])
                                 val nId = noteCursorNonNull.getString(nIdIndex)
-                                note = noteCursorNonNull.getString(nNoteIndex)?:""
+                                note = noteCursorNonNull.getString(nNoteIndex) ?: ""
                             }
                         }
 
@@ -113,8 +107,9 @@ class ContactDatasource(context: Context) {
                     }
                 }
             }
-
-            callback(contactInfoList)
+            withContext(Dispatchers.Main) {
+                callback(contactInfoList)
+            }
         }
     }
 }

--- a/app/src/main/java/com/nbc/two_of_us/data/ContactDatasource.kt
+++ b/app/src/main/java/com/nbc/two_of_us/data/ContactDatasource.kt
@@ -1,4 +1,4 @@
-package com.nbc.two_of_us.permission
+package com.nbc.two_of_us.data
 
 import android.content.Context
 import android.provider.ContactsContract
@@ -6,7 +6,6 @@ import android.provider.ContactsContract.CommonDataKinds.Email
 import android.provider.ContactsContract.CommonDataKinds.Note
 import android.provider.ContactsContract.CommonDataKinds.Phone
 import androidx.core.net.toUri
-import com.nbc.two_of_us.data.ContactInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/nbc/two_of_us/data/ContactInfo.kt
+++ b/app/src/main/java/com/nbc/two_of_us/data/ContactInfo.kt
@@ -4,12 +4,6 @@ import android.net.Uri
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-/**
-
-연락처 정보를 나타내는 클래스 입니다.
-[이 줄과 아래 내용은 구현 후에 삭제해주세요.]
-해당 데이터를 수정해야 하는 경우, var로 변경해서 수정하지 마시고, data class의 copy를 이용해주세요.
- */
 @Parcelize
 data class ContactInfo(
     val name: String, // 이름
@@ -23,8 +17,7 @@ data class ContactInfo(
 
     companion object {
         var id: Int = 0
-            get() = synchronized(this) {
-                field++
-            }
+            get() = field++
+            private set
     }
 }

--- a/app/src/main/java/com/nbc/two_of_us/presentation/ContactInfoViewModel.kt
+++ b/app/src/main/java/com/nbc/two_of_us/presentation/ContactInfoViewModel.kt
@@ -4,41 +4,40 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.nbc.two_of_us.data.ContactInfo
-import com.nbc.two_of_us.data.ContactManager
 import com.nbc.two_of_us.util.Event
 
 class ContactInfoViewModel : ViewModel() {
+
+    private val _contactLiveDataForEdit = MutableLiveData<Event<ContactInfo>>()
+    val contactLiveDataForEdit: LiveData<Event<ContactInfo>> = _contactLiveDataForEdit
+
+    private val _contactLiveDataForDelete = MutableLiveData<Event<ContactInfo>>()
+    val contactLiveDataForDelete: LiveData<Event<ContactInfo>> = _contactLiveDataForDelete
+
+    private val _newContactInfo = MutableLiveData<Event<ContactInfo>>()
+    val newContactInfo: LiveData<Event<ContactInfo>>
+        get() = _newContactInfo
 
     /**
      * @author 이준영
      * for detail fragment
      * */
-    private val _contactLiveDataForEdit = MutableLiveData<Event<ContactInfo>>()
-    val contactLiveDataForEdit: LiveData<Event<ContactInfo>> = _contactLiveDataForEdit
     fun setContactForEdit(contactInfo: ContactInfo, count: Int = 2) {
         _contactLiveDataForEdit.value = Event(contactInfo, count = count)
     }
-
 
     /**
      * @author 이준영
      * for delete a contact info
      * */
-    private val _contactLiveDataForDelete = MutableLiveData<Event<ContactInfo>>()
-    val contactLiveDataForDelete: LiveData<Event<ContactInfo>> = _contactLiveDataForDelete
     fun setDeletedContact(contactInfo: ContactInfo) {
         _contactLiveDataForDelete.value = Event(contactInfo)
     }
-
 
     /**
      * @author 이종성
      * 새로운 연락처가 추가되었을 때를 위함
      * */
-    private val _newContactInfo = MutableLiveData<Event<ContactInfo>>()
-    val newContactInfo: LiveData<Event<ContactInfo>>
-        get() = _newContactInfo
-
     fun setNewContactInfo(contactInfo: ContactInfo) {
         _newContactInfo.value = Event(contactInfo)
     }

--- a/app/src/main/java/com/nbc/two_of_us/presentation/contact/ContactAdapter.kt
+++ b/app/src/main/java/com/nbc/two_of_us/presentation/contact/ContactAdapter.kt
@@ -20,6 +20,9 @@ class ContactAdapter :
     private var contacts: MutableList<ContactInfo> = mutableListOf()
 
     fun add(contacts: List<ContactInfo>) {
+        if (contacts.isEmpty()) {
+            return
+        }
         this.contacts.addAll(contacts)
         notifyItemInserted(contacts.size)
     }
@@ -45,10 +48,6 @@ class ContactAdapter :
         }
         contacts.removeAt(index)
         notifyItemRemoved(index)
-    }
-
-    fun updateList(contactList: List<ContactInfo>) {
-        contacts = contactList.toMutableList()
     }
 
     interface ItemClick {

--- a/app/src/main/java/com/nbc/two_of_us/presentation/contact/ContactListFragment.kt
+++ b/app/src/main/java/com/nbc/two_of_us/presentation/contact/ContactListFragment.kt
@@ -16,10 +16,10 @@ import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.nbc.two_of_us.R
+import com.nbc.two_of_us.data.ContactDatasource
 import com.nbc.two_of_us.data.ContactInfo
 import com.nbc.two_of_us.data.ContactManager
 import com.nbc.two_of_us.databinding.FragmentContactListBinding
-import com.nbc.two_of_us.permission.ContactDatasource
 import com.nbc.two_of_us.permission.PermissionManager
 import com.nbc.two_of_us.presentation.ContactInfoViewModel
 import com.nbc.two_of_us.presentation.contact_detail.ContactDetailFragment

--- a/app/src/main/java/com/nbc/two_of_us/util/Event.kt
+++ b/app/src/main/java/com/nbc/two_of_us/util/Event.kt
@@ -1,6 +1,6 @@
 package com.nbc.two_of_us.util
 
-open class Event<out T>(private val content: T, private var count: Int = 1) {
+class Event<out T>(private val content: T, private var count: Int = 1) {
 
     @Suppress("MemberVisibilityCanBePrivate")
     var hasBeenHandled = false


### PR DESCRIPTION
## 왜 open class 인가요?
A. 아래 소스 코드의 클래스를 아무 생각없이 복붙해서 사용했습니다.
상속하는 클래스가 없기 때문에 open 키워드를 지웠습니다.

https://github.com/android/architecture-samples/blob/dev-dagger/app/src/main/java/com/example/android/architecture/blueprints/todoapp/Event.kt

[refactor: Event 클래스를 상속하는 클래스가 없으므로 open 접근자 제거](https://github.com/AndroidJeong/NBC_TwoOfUs/commit/e464034c4f5010b5d94f058b263252bc0fd7fe32)


## 두곳에서 접근? 
Q.
synchronized는 멀티스레드 환경에서 특정 영역을 동기화 처리 하기 위해 쓰입니다.
멀티스레딩 요소가 전혀 없어보입니다.
또한 get 할때 (read) 때에는 N개의 접근이 있어도 상관이 없습니다.
```kotlin
fun getContentIfNotHandled(): T? { 
    return synchronized(this) { 
```

A.
아래와 같이 세 곳에서 동시에 observing 하는 경우를 대응하기 위해 필요할 것 같습니다.

![img1 daumcdn](https://github.com/AndroidJeong/NBC_TwoOfUs/assets/48354989/9f00d61e-3342-4953-9251-573c8a3163fb)

## with(binding)
Q.
이런식으로 함수전체를 랩핑하는것은 가독성도 떨어지고 필요한 부분 최소한의 영역에서만 사용하면 좋을것같습니다.

`private fun setBackPressed() = with(binding) `

A.
앞에 binding 코드를 작성하지 않아도 되고, 내부에 with(binding)을 적을 때 발생하는 depth + 1을 줄일 수 있다고 생각해서 적었는데, 무조건 남발하면 안 되는 거군요.

## ViewPagerAdpater 생성자
Q. 
TODO 보통은 이걸 사용하면 자동으로 fm과 lifecycle을 전달
```kotlin
public FragmentStateAdapter(@NonNull FragmentActivity fragmentActivity) {
public FragmentStateAdapter(@NonNull Fragment fragment) {
```
FragmentStateAdapter(fm, lifecycle) //를 사용한 이유가 있을지?

A.

fragment를 전달할 경우, memory leak이 발생했습니다. (canary leak으로 확인)


## 파일 분리
Q.

permission폴더에 같이 있는게 조금 애매합니다.
```kotlin
class ContactDatasource(context: Context) {
```

A. permission 패키지에서 data 패키지로 옮겼습니다.

[refactor: ContactDatasource 클래스를 permission 패키지에서 data 패키지로 이동](https://github.com/AndroidJeong/NBC_TwoOfUs/pull/26/commits/6aec128134f8908ecb66dc495c54dde4e5c183c7)

## 동기화
이부분도 동기화가 필요 없어 보입니다. 필요없는 동기화는 성능을 저하시킵니다.

```kotlin
data class ContactInfo(
 companion object {
    var id: Int = 0
        get() = synchronized(this) { 
            field++
        }
}
```

id가 중복 생성되는 일을 막기 위해 동기화 처리를 해줬는데, 동기화 블록을 삭제했습니다.
또한 외부에서 값을 변경할 수 없도록 setter에 private 접근자를 추가했습니다.

[refactor: ContactInfo의 동기화 블록 삭제, 외부에서 값을 변경할 수 없도록 setter에 private 접…](https://github.com/AndroidJeong/NBC_TwoOfUs/pull/26/commits/3ddf6fb1660c8f9d9a186360623606d7e8594aab)


## Dispatcher
Q.
dispatcher를 지정할거면 IO(백스레드)에서 하는게 좋아보입니다.
메인스레드에서 바쁜일을 시키면 안됩니다.
`CoroutineScope(Dispatchers.Main).launch {`

A.
ContactDatasource 함수에서 IO 쓰레드를 이용해 연락처 정보를 가져오고, callback 함수는 Main 쓰레드에서 실행되도록 수정했습니다.

[refactor: ContactDatasource 함수에서 IO 쓰레드를 이용해 연락처 정보를 가져오고, callback 함…](https://github.com/AndroidJeong/NBC_TwoOfUs/pull/26/commits/7d7f0eff00e603b67413533898ad107f35e27b69)


## ViewModel
Q.
나중에는 viewmodel없이도 구현해보시길...
이 클래스에서 변수는 변수끼리, 함수는 함수끼리 정렬하는것이 좋겠습니다.
`class ContactInfoViewModel : ViewModel() {`


A.
[chore: ContactInfoViewModel 코드 정리](https://github.com/AndroidJeong/NBC_TwoOfUs/pull/26/commits/d2530a7dfe4e1c38b42734685273b7712df6fc8f)

## Exception
Q.
연락처가 하나도 없을경우, 아래 부분에서 exception이 발생 합니다.
```kotlin
fun add(contacts: List<ContactInfo>) {
    this.contacts.addAll(contacts)
    notifyItemInserted(contacts.size) 
}
```

A.

[fix: 기기 연락처에 연락처 정보가 없는 경우 대응](https://github.com/AndroidJeong/NBC_TwoOfUs/pull/26/commits/e23217ad87d8b199a94c7e5cd606a169cdae0a84)


## Lazy
Q.
 lazy는 많이 사용시 성능에 좋지 않습니다.


A.

lazy를 사용한 변수들은 context가 필요한데, Fragment에서 property가 생성되는 시점에는 Activity에 attach 되지 않아 context가 없어 lazy로 설정했습니다.

## scope function

이런식의 Let run 사용은 가독성을 오히려 떨어트립니다.
차라리 누가봐도 알수있는 If else가 더 좋습니다.
```kotlin
detailInfo?.let {
    updateUI(it) //심지어 여기가 null이라면 아래라인을 또 탈수도있습니다.
} ?: run {
    //...
}
```

A.

if else 문을 사용하면 detailInfo에 대한 null check가 애매해져서 scope function을 사용했습니다.

![image](https://github.com/AndroidJeong/NBC_TwoOfUs/assets/48354989/ca8345de-1c51-4796-8cba-a8d857cc4b2b)
